### PR TITLE
Release finschia-kt v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 ### Changed
-* [\#6](https://github.com/Finschia/finschia-kt/pull/6) Rename package 'ln.v2' -> 'sdk'
-* (ci) [\#11](https://github.com/Finschia/finschia-kt/pull/11) Add ci/cd to publish to maven
 
 ### Deprecated
 
@@ -54,9 +52,20 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Build, CI
 
-* (build) [\#4](https://github.com/Finschia/finschia-kt/pull/4) Add gradle `updateSubmodule` task and `checkoutSubModule` task to run `git submodule update --init --remote` with specific version before `build task` 
-
 ### Document Updates
 
+
+## [v0.2.1]
+
+### Changed
+* [\#6](https://github.com/Finschia/finschia-kt/pull/6) Rename package 'ln.v2' -> 'sdk'
+* (ci) [\#11](https://github.com/Finschia/finschia-kt/pull/11) Add ci/cd to publish to maven
+
+### Build, CI
+
+* (build) [\#4](https://github.com/Finschia/finschia-kt/pull/4) Add gradle `updateSubmodule` task and `checkoutSubModule` task to run `git submodule update --init --remote` with specific version before `build task`
+
+
 <!-- Release links -->
-[Unreleased]: https://github.com/Finschia/finschia-kt/compare/8aa2005...HEAD
+[Unreleased]: https://github.com/Finschia/finschia-kt/compare/v0.2.1...HEAD
+[v0.2.1]: https://github.com/Finschia/finschia-kt/compare/8aa2005...v0.2.1

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 gRPC client library in kotlin for finschia (https://github.com/Finschia/finschia).
 
-Requires [finschia-sdk v0.47.0-alpha1](https://github.com/Finschia/finschia-sdk/tree/v0.47.0-alpha1)
+Requires [finschia-sdk v0.47.0](https://github.com/Finschia/finschia-sdk/tree/v0.47.0)
 
-Current finschia-sdk version applied to finschia-kt/protobuf is [finschia-sdk v0.47.0-alpha1](https://github.com/Finschia/finschia-sdk/tree/v0.47.0-alpha1)
+Current finschia-sdk version applied to finschia-kt/protobuf is [finschia-sdk v0.47.0](https://github.com/Finschia/finschia-sdk/tree/v0.47.0)
 
 ## Build
 
@@ -90,7 +90,7 @@ The former is using the tx wrapper, while the latter does not use the wrapper.
 
 ### 1. Run finschia-sdk simapp
 
-Build with reference to [Quick Start build](https://github.com/Finschia/finschia-sdk/tree/v0.47.0-alpha1#quick-start).
+Build with reference to [Quick Start build](https://github.com/Finschia/finschia-sdk/tree/v0.47.0#quick-start).
 
 Initialize and configure simapp.
 

--- a/README.md
+++ b/README.md
@@ -11,24 +11,7 @@ Current finschia-sdk version applied to finschia-kt/protobuf is [finschia-sdk v0
 You can build the project by following command, which also runs all the unit tests:
 
 ```shell
-$ git submodule update --init
 $ ./gradlew build
-```
-
-Note that any version of finschia-kt is only compatible with a certain finschia-sdk version. The corresponding finschia-sdk
-version that the current repository supports can be found in the tag or commit hash of `proto/repositories/finschia-sdk`
-submodule, using the following command.
-
-```shell
-$ cd protobuf/repositories/finschia-sdk && git describe --always && cd -
-```
-
-If you are a finschia-kt developer or contributor and trying to use another version of finschia-sdk, `git checkout`
-the appropriate version in the finschia-sdk submodule before building this repository. The following command is an example
-of using finschia-sdk `v0.47.0-alpha1`.
-
-```shell
-$ cd protobuf/repositories/finschia-sdk && git checkout v0.47.0-alpha1 && cd -
 ```
 
 ## How to use


### PR DESCRIPTION
# Release v0.2.1

## Changed
* [\#6](https://github.com/Finschia/finschia-kt/pull/6) Rename package 'ln.v2' -> 'sdk'
* (ci) [\#11](https://github.com/Finschia/finschia-kt/pull/11) Add ci/cd to publish to maven

## Build, CI

* (build) [\#4](https://github.com/Finschia/finschia-kt/pull/4) Add gradle `updateSubmodule` task and `checkoutSubModule` task to run `git submodule update --init --remote` with specific version before `build task`


