### PR TITLE
Change the value of AminoMsg to the general type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 ### Changed
+build: [#19](https://github.com/Finschia/finschia-kt/pull/19) Change the value of AminoMsg to the general type
 
 ### Deprecated
 

--- a/examples/multisig-example/src/main/kotlin/network/finschia/sdk/example/Client.kt
+++ b/examples/multisig-example/src/main/kotlin/network/finschia/sdk/example/Client.kt
@@ -29,6 +29,78 @@ class TxClient(private val channel: ManagedChannel) : Closeable {
     }
 }
 
+class MultisigMsgDelegate {
+    companion object {
+        fun createMsgDelegate(
+            delegatorAddress: String,
+            validatorAddress: String,
+            amounts: cosmos.base.v1beta1.CoinOuterClass.Coin
+        ): cosmos.staking.v1beta1.Tx.MsgDelegate {
+            return cosmos.staking.v1beta1.msgDelegate {
+                this.delegatorAddress = delegatorAddress
+                this.validatorAddress = validatorAddress
+                this.amount = amounts
+            }
+        }
+        fun convertMsgDelegatorToAminoMsg(msgDelegate: cosmos.staking.v1beta1.Tx.MsgDelegate): AminoMsg {
+
+            val jsonAminoMsgDelegateValue = AminoMsgDelegateValue(
+                delegatorAddress = msgDelegate.delegatorAddress,
+                validatorAddress = msgDelegate.validatorAddress,
+                amount = Coin(
+                    denom = msgDelegate.amount.denom,
+                    amount = msgDelegate.amount.amount
+                )
+
+            )
+
+            return AminoMsg(
+                type = "cosmos-sdk/MsgDelegate",
+                value = Json.encodeToJsonElement(jsonAminoMsgDelegateValue)
+            )
+        }
+
+        fun generateTxBody(
+            delegateMsg: cosmos.staking.v1beta1.Tx.MsgDelegate,
+            timeoutHeight: Int
+        ): cosmos.tx.v1beta1.TxOuterClass.TxBody {
+            return cosmos.tx.v1beta1.txBody {
+                this.messages += com.google.protobuf.any {
+                    this.typeUrl = "/cosmos.staking.v1beta1.MsgDelegate"
+                    this.value = delegateMsg.toByteString()
+                }
+                this.timeoutHeight = timeoutHeight.toLong()
+            }
+        }
+
+        fun getSignDigest(signDoc: StdSignDoc): ByteArray {
+            return SHA256.Digest()
+                .digest(Json.encodeToJsonElement(signDoc).removeNull().sort().toString().toByteArray())
+        }
+
+        fun generateSignDoc(
+            sendMsgs: List<cosmos.staking.v1beta1.Tx.MsgDelegate>,
+            accNum: Int,
+            accSeq: Int,
+            timeoutHeight: Int = 0,
+            gasLimit: Int,
+            chainId: String
+        ): StdSignDoc {
+            return StdSignDoc(
+                accountNumber = accNum.toString(),
+                sequence = accSeq.toString(),
+                timeoutHeight = if (timeoutHeight <= 0) null else timeoutHeight.toString(),
+                chainId = chainId,
+                memo = "",
+                fee = StdFee(
+                    amount = listOf(Coin(amount = "20", denom = "cony")),
+                    gas = gasLimit.toString(),
+                ),
+                msgs = sendMsgs.map { convertMsgDelegatorToAminoMsg(it) },
+            )
+        }
+    }
+}
 class MultisigMsgSend {
     companion object {
         fun addressFromMultiPubKey(
@@ -62,14 +134,15 @@ class MultisigMsgSend {
                     amount = it.amount.toString()
                 )
             }
+            val jsonAminoMsgSend = AminoMsgSendValue(
+                fromAddress = msgSend.fromAddress,
+                amount = coins,
+                toAddress = msgSend.toAddress,
+            )
 
             return AminoMsg(
                 type = "cosmos-sdk/MsgSend",
-                value = AminoMsgValue(
-                    amount = coins,
-                    fromAddress = msgSend.fromAddress,
-                    toAddress = msgSend.toAddress,
-                )
+                value = Json.encodeToJsonElement(jsonAminoMsgSend)
             )
         }
 
@@ -106,7 +179,7 @@ class MultisigMsgSend {
                 chainId = chainId,
                 memo = "",
                 fee = StdFee(
-                    amount = emptyList(),
+                    amount = listOf(Coin(amount = "20", denom = "cony")),
                     gas = gasLimit.toString(),
                 ),
                 msgs = sendMsgs.map { convertMsgSendToAminoMsg(it) },
@@ -166,14 +239,14 @@ suspend fun main() {
     // multi-sig address
     val multiSigAddress = pubkeyToAddress(multiSigPubKey, accountPrefix)
     val multiSigAccNum = 9
-    val multiSigAccSeq = 0
+    var multiSigAccSeq = 0
     val timeoutHeight = 0
 
     // receiver address
     val recipientAddress = Address(hdWallet.getKeyWallet(pubKeyNum + 1).pubKey).toBech32(accountPrefix)
     // remittance amount
     val fundAmount = 1
-    val baseDenom = "stake"
+    val baseDenom = "cony"
 
     // scenario description
     println(
@@ -237,4 +310,57 @@ suspend fun main() {
     //-----------------------------------------
     val result = client.broadcastTx(signedTx)
     println("result: $result")
+    multiSigAccSeq++
+    val stakeDenom = "stake"
+    // scenario description
+    val validatorAddress = "linkvaloper1twsfmuj28ndph54k4nw8crwu8h9c8mh33lyrp8" //change for yourself
+    println(
+        "scenario: " +
+                "$multiSigAddress ($threshold of $pubKeyNum multi-sig address, acc num: $multiSigAccNum, acc seq: $multiSigAccSeq) delegate $fundAmount$stakeDenom to $validatorAddress on $chainId chain. " +
+                "Gas limit is set to $gasLimit and timeout height is ${if (timeoutHeight <= 0) "not set" else "set to $timeoutHeight"}."
+    )
+
+    // generate sendDelegate
+    val msgDelegate = MultisigMsgDelegate.createMsgDelegate(
+        multiSigAddress,
+        validatorAddress,
+        cosmos.base.v1beta1.coin {
+            this.amount = fundAmount.toString()
+            this.denom = stakeDenom
+        }
+    )
+
+    // generate unsigned tx body(amino type)
+    val txDelegateBody = MultisigMsgDelegate.generateTxBody(msgDelegate, timeoutHeight)
+
+    // generate amino signDoc
+    val delegateUnsignedSignDoc = MultisigMsgDelegate.generateSignDoc(
+        listOf(msgDelegate),
+        multiSigAccNum,
+        multiSigAccSeq,
+        timeoutHeight,
+        gasLimit,
+        chainId
+    )
+
+    // generate sign digest
+    val signDigestDelegate = MultisigMsgDelegate.getSignDigest(delegateUnsignedSignDoc)
+
+    val signerToSigsDelegate: Map<String, ByteString> = signers.map {
+        it.address.toBech32(accountPrefix) to ByteString.copyFrom(it.sign(signDigestDelegate).copyOfRange(0, 64))
+    }.toMap()
+
+    val signedDelegateTx = makeMultisignedTx(
+        multiSigPubKey,
+        multiSigAccSeq,
+        unsignedSignDoc.fee,
+        txDelegateBody.toByteString(),
+        signerToSigsDelegate
+    )
+
+    //-----------------------------------------
+    // step 6: broadcast the signed tx
+    //-----------------------------------------
+    val resultDelegate = client.broadcastTx(signedDelegateTx)
+    println("result: $resultDelegate")
 }

--- a/examples/multisig-example/src/main/kotlin/network/finschia/sdk/example/Client.kt
+++ b/examples/multisig-example/src/main/kotlin/network/finschia/sdk/example/Client.kt
@@ -4,6 +4,8 @@ import network.finschia.sdk.legacymultisig.*
 import com.google.protobuf.ByteString
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.*
@@ -310,6 +312,12 @@ suspend fun main() {
     //-----------------------------------------
     val result = client.broadcastTx(signedTx)
     println("result: $result")
+
+
+    //-----------------------------------------
+    // `MsgDelegate` scenario example
+    //-----------------------------------------
+
     multiSigAccSeq++
     val stakeDenom = "stake"
     // scenario description
@@ -358,9 +366,7 @@ suspend fun main() {
         signerToSigsDelegate
     )
 
-    //-----------------------------------------
-    // step 6: broadcast the signed tx
-    //-----------------------------------------
+    // broadcast the signed tx
     val resultDelegate = client.broadcastTx(signedDelegateTx)
     println("result: $resultDelegate")
 }

--- a/tx/src/main/kotlin/network/finschia/sdk/legacymultisig/SignDoc.kt
+++ b/tx/src/main/kotlin/network/finschia/sdk/legacymultisig/SignDoc.kt
@@ -12,14 +12,21 @@ import kotlinx.serialization.json.*
 @Serializable
 data class AminoMsg(
     @SerialName("type") val type: String,
-    @SerialName("value") val value: AminoMsgValue,
+    @SerialName("value") val value: JsonElement,
 )
 
 @Serializable
-data class AminoMsgValue(
+data class AminoMsgSendValue(
     @SerialName("amount") val amount: List<Coin>,
     @SerialName("from_address") val fromAddress: String,
     @SerialName("to_address") val toAddress: String,
+)
+
+@Serializable
+data class AminoMsgDelegateValue(
+    @SerialName("amount") val amount: Coin,
+    @SerialName("delegator_address") val delegatorAddress: String,
+    @SerialName("validator_address") val validatorAddress: String,
 )
 
 @Serializable

--- a/tx/src/main/kotlin/network/finschia/sdk/legacymultisig/SignDoc.kt
+++ b/tx/src/main/kotlin/network/finschia/sdk/legacymultisig/SignDoc.kt
@@ -15,6 +15,9 @@ data class AminoMsg(
     @SerialName("value") val value: JsonElement,
 )
 
+/**
+ * You can create many amino messages for other Msg: MsgUndelegate, MsgCreateValidator, MsgEditValidator.... by yourself
+ */
 @Serializable
 data class AminoMsgSendValue(
     @SerialName("amount") val amount: List<Coin>,


### PR DESCRIPTION
Change the value of AminoMsg to the general type

## Description
Currently, the AminoMsg is only supported the MsgSend, It's hard to use the tx module. Thus, I change the value of AminoMsg to JsonElement. It's easy to implement with other messages: MsgDelegate, MsgUnDelegate.....

## Motivation and context
It's hard to use the AminoMsg for other messages, I improve it to use with all messages.

## How has this been tested?
I add the testing code in the examples/multisig-example. Please use it to test by yourself.

## Screenshots (if appropriate):

## Checklist:
- [x] I have added a relevant changelog to `CHANGELOG.md`.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
